### PR TITLE
Adds createFragmentToCreateMock transform

### DIFF
--- a/src/createFragmentToCreateMock.js
+++ b/src/createFragmentToCreateMock.js
@@ -18,7 +18,7 @@ let graphqlTypeName;
  */
 const buildCreateMockParams = (node) => {
   const id = node.arguments[0];
-  const overrides = node.arguments?.[1] ?? b.objectExpression([]);
+  let overrides = node.arguments[1] ?? b.objectExpression([]);
 
   node.callee.name = "createMock";
 
@@ -29,7 +29,14 @@ const buildCreateMockParams = (node) => {
     ),
   ]);
 
+  // In the case where a variable is being passed directly into create*Fragment
+  // Ex: createVariantFragment("1", variantOptions);
+  if (overrides.type === "Identifier") {
+    overrides = b.objectExpression([b.spreadElement(overrides)]);
+  }
+
   overrides.properties.unshift(b.objectProperty(b.identifier("id"), id));
+
   createMockParam.properties.push(
     b.objectProperty(b.identifier("overrides"), overrides)
   );

--- a/src/createFragmentToCreateMock.js
+++ b/src/createFragmentToCreateMock.js
@@ -1,0 +1,94 @@
+import { visit, types } from "recast";
+
+const b = types.builders;
+let needToImportCreateMock = true;
+let rtlImportNode = null;
+let parentNode;
+
+const buildCreateMockParams = (node) => {
+  const id = node.arguments[0];
+  const overrides = node.arguments?.[1] ?? {};
+
+  node.callee.name = "createMock";
+
+  const createMockParam = b.objectExpression([
+    b.objectProperty(b.identifier("typeName"), b.stringLiteral("Patient")),
+  ]);
+
+  overrides.properties.unshift(b.objectProperty(b.identifier("id"), id));
+  createMockParam.properties.push(
+    b.objectProperty(b.identifier("overrides"), overrides)
+  );
+
+  return createMockParam;
+};
+
+const addCreateMockImport = () => {
+  if (rtlImportNode) {
+    rtlImportNode.specifiers.push(
+      b.importSpecifier(b.identifier("createMock"))
+    );
+  } else {
+    // need to add via parentNode
+    parentNode.body.unshift(
+      b.importDeclaration(
+        b.importSpecifier(b.identifier("createMock")),
+        b.stringLiteral("@testing/createMock"),
+      )
+    );
+  }
+};
+
+const transform = (ast, callback) => {
+  visit(ast, {
+    visitProgram(path) {
+      needToImportCreateMock = true;
+      parentNode = path.node;
+      rtlImportNode = null;
+
+      this.traverse(path);
+    },
+    visitImportDeclaration(path) {
+      // already imported createMock
+      if (path.node.source.value === "@testing/createMock") {
+        needToImportCreateMock = false;
+      }
+
+      if (path.node.source.value === "@testing/rtl") {
+        // verify if createMock is already imported
+        const hasImportedCreateMock = path.node.specifiers.find((specifier) => {
+          return specifier?.imported?.name === "createMock";
+        });
+
+        if (hasImportedCreateMock) {
+          needToImportCreateMock = false;
+        } else {
+          rtlImportNode = path.node;
+        }
+      }
+
+      this.traverse(path);
+    },
+    visitCallExpression(path) {
+      if (path.node.callee.name === "createPatientFragment") {
+        // If there's a match, then we need to also import `createMock` depending on needToImportCreateMock
+        const createMockParam = buildCreateMockParams(path.node);
+
+        path.node.arguments = [createMockParam];
+
+        if (needToImportCreateMock) {
+          addCreateMockImport();
+
+          // We have now added the import statement, no need to do so again for other instances of create*Fragment
+          needToImportCreateMock = false;
+        }
+      }
+
+      this.traverse(path);
+    },
+  });
+
+  callback(ast);
+};
+
+export { transform };

--- a/src/index.js
+++ b/src/index.js
@@ -8,10 +8,10 @@ const VALID_TRANSFORM_NAMES = [
   "createFragmentToCreateMock",
 ];
 
-const parseCode = code => {
+const parseCode = (code) => {
   return parse(code, {
     parser: {
-      parse: source => {
+      parse: (source) => {
         return babelParser.parse(source, {
           // sourceFilename: options.fileName,
           allowAwaitOutsideFunction: true,
@@ -59,10 +59,12 @@ const parseCode = code => {
   });
 };
 
-const transformToRun = process.argv[2];
-const filePaths = glob.sync(process.argv[3]);
+const [_1, _2, transformToRun, pathGlob, ...transformOptions] = process.argv;
+const filePaths = glob.sync(pathGlob);
 
-const validTransform = VALID_TRANSFORM_NAMES.find((transformName) => transformName === transformToRun);
+const validTransform = VALID_TRANSFORM_NAMES.find(
+  (transformName) => transformName === transformToRun
+);
 
 if (!validTransform) {
   throw new Error(`${transformToRun} is not a valid transform name.`);
@@ -77,16 +79,16 @@ filePaths.forEach((filePath) => {
 
     const { transform } = await import(`./${transformToRun}.js`);
 
-    transform(parseCode(code), node => {
-      const transformedCode = print(node).code;
-      
-      if (process.argv[3] === "--dry-run") {
-        console.log(transformedCode);
-      } else {
-        writeFile(filePath, transformedCode, writeError => {
+    transform(
+      parseCode(code),
+      (node) => {
+        const transformedCode = print(node).code;
+
+        writeFile(filePath, transformedCode, (writeError) => {
           console.log(writeError);
         });
-      }
-    });
+      },
+      transformOptions
+    );
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import { parse, print } from "recast";
 
 const VALID_TRANSFORM_NAMES = [
   "createMockToObjectParams",
+  "createFragmentToCreateMock",
 ];
 
 const parseCode = code => {


### PR DESCRIPTION
I've also made some temporary changes to how arguments are parsed and passed in the index file. This is really just temporary, my end goal here is to add `yargs` and create more powerful argument logic. The benefit to that is ideally each transform can specify its own possible CLI flags in cases where you want a transform to take input.

Example in this case this transform is used as such:

`yarn transform createFragmentToCreateMock '../hw-admin/app/javascript/**/*.spec.tsx' createPractitionerFragment Practitioner`

Ideally this could eventually become:
`yarn transform createFragmentToCreateMock '../hw-admin/app/javascript/**/*.spec.tsx' --createFragmentFunction createPractitionerFragment --typeName Practitioner`

etc.