### PR TITLE
Add eslint disable for graphql hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,23 @@ Example:
 yarn transform lTranslation '../hw-admin/app/javascript/patient/**/*.ts*' --options @patient/locales
 ```
 
+#### addEslintDisableComment
+
+To temporarily suppress custom eslint rule to prevent using the manually declared GraphQL hook
+
+Usage:
+
+```sh
+yarn transform addEslintDisableComment '../hw-admin/app/javascript/<namespace>/**/*.ts*' 
+```
+
+Example:
+
+```sh
+yarn transform addEslintDisableComment '../hw-admin/app/javascript/patient/**/*.ts*'
+```
+
+
 ### CLI
 
 The CLI usage is as follows:
@@ -119,3 +136,4 @@ yarn transform <transformName> <filesToTransformAsGlob> --dry-run --options
 - **filesToTransformAsGlob**: A glob pattern **in quotations** identifying files to run the transform against. Ex: '../projectDir/src/\*\*/\*.tsx'
 - **`--dry-run` or `-d` for short**: Output transform result to console rather than writing changes to files. Useful during development.
 - **`--options`**: An array of optional parameters to pass into the specified transform. Some transforms require additional user input, this is how you specify that. See [colorsToTheme](#colorstotheme) for an example.
+

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ yarn transform addEslintDisableComment '../hw-admin/app/javascript/<namespace>/*
 Example:
 
 ```sh
-yarn transform addEslintDisableComment '../hw-admin/app/javascript/patient/**/*.ts*'
+yarn transform addEslintDisableComment '../hw-admin/app/javascript/patient/**/*.query.ts*'
 ```
 
 

--- a/src/transforms/addEslintDisableComment.js
+++ b/src/transforms/addEslintDisableComment.js
@@ -22,15 +22,15 @@ const transform = ({ builder }) => {
 
       if (includesHook) {
         const newDeclarations = path.node.specifiers.map((_, index) => {
-          if (index === 0) {
             const newDeclaration = builder.exportNamedDeclaration(path.node.declaration, [
               ...path.node.specifiers,
             ]);
+          if (index === 0) {
             newDeclaration.comments = [
               builder.commentBlock("eslint-disable @fullscript/gql-no-manual-hook-declaration"),
             ];
+            return newDeclaration;
           }
-          return newDecl;
         });
         path.replace.apply(path, newDeclarations);
       }

--- a/src/transforms/addEslintDisableComment.js
+++ b/src/transforms/addEslintDisableComment.js
@@ -12,7 +12,7 @@
  * @returns {import("ast-types").Visitor}
  */
 
-const reactHookPrefix = new RegExp("use\\w+");
+const reactHookPrefix = new RegExp("^use\\w+");
 const transform = ({ builder }) => {
   return {
     visitExportNamedDeclaration(path) {
@@ -28,7 +28,7 @@ const transform = ({ builder }) => {
         const newDeclarations = path.node.specifiers.map((_, index) => {
           if (index === 0) {
             newDeclaration.comments = [
-              builder.commentBlock("eslint-disable @fullscript/gql-no-manual-hook-declaration "),
+              builder.commentBlock(" eslint-disable @fullscript/gql-no-manual-hook-declaration "),
             ];
             return newDeclaration;
           }

--- a/src/transforms/addEslintDisableComment.js
+++ b/src/transforms/addEslintDisableComment.js
@@ -12,8 +12,8 @@
  * @returns {import("ast-types").Visitor}
  */
 
+const reactHookPrefix = new RegExp("use\\w+");
 const transform = ({ builder }) => {
-  const reactHookPrefix = new RegExp("use\\w+");
   return {
     visitExportNamedDeclaration(path) {
       const includesHook = path.node.specifiers.some(specifier => {
@@ -21,10 +21,11 @@ const transform = ({ builder }) => {
       });
 
       if (includesHook) {
+        // create exact copy of the export declaration
+        const newDeclaration = builder.exportNamedDeclaration(path.node.declaration, [
+          ...path.node.specifiers,
+        ]);
         const newDeclarations = path.node.specifiers.map((_, index) => {
-            const newDeclaration = builder.exportNamedDeclaration(path.node.declaration, [
-              ...path.node.specifiers,
-            ]);
           if (index === 0) {
             newDeclaration.comments = [
               builder.commentBlock("eslint-disable @fullscript/gql-no-manual-hook-declaration "),

--- a/src/transforms/addEslintDisableComment.js
+++ b/src/transforms/addEslintDisableComment.js
@@ -1,0 +1,42 @@
+/**
+ * Type definitions for VSCode autocompletion!
+ *
+ * @typedef {Object} TransformParams
+ * @property {*} ast - The resulting AST as parsed by babel
+ * @property {import("ast-types/gen/builders").builders} builder - Recast builder for transforming the AST
+ * @property {*} options - Options passed into the transform from the CLI (if any)
+ */
+
+/**
+ * @param {TransformParams} param0
+ * @returns {import("ast-types").Visitor}
+ */
+
+const transform = ({ builder }) => {
+  const reactHookPrefix = new RegExp("use\\w+");
+  return {
+    visitExportNamedDeclaration(path) {
+      const includesHook = path.node.specifiers.some(specifier => {
+        if (reactHookPrefix.test(specifier.local.name)) return true;
+      });
+
+      if (includesHook) {
+        const newDeclarations = path.node.specifiers.map((_, index) => {
+          if (index === 0) {
+            const newDeclaration = builder.exportNamedDeclaration(path.node.declaration, [
+              ...path.node.specifiers,
+            ]);
+            newDeclaration.comments = [
+              builder.commentBlock("eslint-disable @fullscript/gql-no-manual-hook-declaration"),
+            ];
+          }
+          return newDecl;
+        });
+        path.replace.apply(path, newDeclarations);
+      }
+    },
+  };
+};
+
+export { transform };
+

--- a/src/transforms/addEslintDisableComment.js
+++ b/src/transforms/addEslintDisableComment.js
@@ -27,7 +27,7 @@ const transform = ({ builder }) => {
             ]);
           if (index === 0) {
             newDeclaration.comments = [
-              builder.commentBlock("eslint-disable @fullscript/gql-no-manual-hook-declaration"),
+              builder.commentBlock("eslint-disable @fullscript/gql-no-manual-hook-declaration "),
             ];
             return newDeclaration;
           }


### PR DESCRIPTION
When we just migrate the existing hook to codegen, we would like to prevent the new query/mutation hooks to be created manually. We already have an ESLint rule to disable it. 

This MR is to allow people to gradually convert by suppressing the eslint line by line while we convert the existing manual declaration.