### PR TITLE
Remove `private` flag and bump `packageManager` to Yarn 4.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "exports": "./src/index.js",
   "author": "ryan.oconnor@fullscript.com",
   "license": "MIT",
-  "private": true,
   "type": "module",
   "scripts": {
     "prettier:format": "prettier --write \"./src/**/*.js\"",

--- a/package.json
+++ b/package.json
@@ -29,5 +29,5 @@
     "prettier": "^3.5.3",
     "vitest": "^2.1.9"
   },
-  "packageManager": "yarn@4.9.1"
+  "packageManager": "yarn@4.13.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullscript/js-transforms",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Local recast transforms for use against hw-admin",
   "exports": "./src/index.js",
   "author": "ryan.oconnor@fullscript.com",


### PR DESCRIPTION
Yarn 4.13.0 passes configuration (including `npmMinimalAgeGate`) as environment variables when packing git-hosted dependencies. Older Yarn versions don't recognise these settings and fail with `YN0058`. Bumping `packageManager` ensures the subprocess understands the parent project's config.

For `js-transforms` specifically, `"private": true` also needed to be removed since Yarn refuses to pack private packages, and this package is consumed as a git dependency.

```
➤ YN0058: │ @fullscript/js-transforms@https://github.com/Fullscript/js-transforms.git#commit=1ee6a55baa266dc6debf0593f55b2007150e014e: Packing the package failed (exit code 1, logs can be found here: /private/var/folders/qs/jwzhlgwn6y7b4vzxvk13ztgc0000gp/T/xfs-512c8f9e/pack.log)
```

## Testing

- In a consuming project that uses Yarn 4.13.0 with `npmMinimalAgeGate` configured, update the git dependency reference to point at the new commit
- Bust your yarn cache with `yarn cache clean`
- Run `yarn install` and confirm the `YN0058` packing error doesn't happen
- Verify the package resolves and installs successfully

Lemme know if this makes sense!